### PR TITLE
Fixed edge case where number of features coincides with block size

### DIFF
--- a/R/calculate.similarity.R
+++ b/R/calculate.similarity.R
@@ -1,12 +1,12 @@
 compute.start <- function(position, blocksize, numcols) {
-  return(min((1 + (position * blocksize)), numcols))
+  return(min((1 + ((position - 1) * blocksize)), numcols))
 }
 
 compute.stop <- function(position, blocksize, numcols) {
-  if ((position + 1) * blocksize > numcols) {
+  if ((position) * blocksize > numcols) {
     stop_pos <- numcols
   } else {
-    stop_pos <- (position + 1) * blocksize
+    stop_pos <- (position) * blocksize
   }
   return(stop_pos)
 }
@@ -25,15 +25,15 @@ calculate.similarity <- function(numcols,
   ########
   # establish some constants for downstream processing
   vlength <- (numcols * (numcols - 1)) / 2
-  nblocks <- floor(numcols / blocksize)
-  
+  nblocks <- ceiling(numcols / blocksize)
+
   cat(paste("Calculating ramclustR similarity using", sum((nblocks+1):1), "nblocks.\n"))
   
   ramclustObj <- vector(mode = "integer", length = vlength)
   block = 1
   column <- NULL
   
-  for (row in 0:(nblocks)) {
+  for (row in 1:(nblocks)) {
     for (col in row:(nblocks)) {
       cat(block, " ")
       block <- block + 1
@@ -106,7 +106,7 @@ calculate.similarity <- function(numcols,
     if (exists("startv") == FALSE)
       startv <- 1
     stopv <- startv + length(column) - 1
-    
+
     # assign obtained vector to result
     ramclustObj[startv:stopv] <- column
     startv <- stopv + 1


### PR DESCRIPTION
This PR includes the following:

- Fixed edge case which was occurring when the number of features and the blocksize were exactly the same, the issue was with the computation in the number of blocks in calculate.similarity function #https://github.com/cbroeckl/RAMClustR/issues/40